### PR TITLE
Add inaugural blog post: Android to AI career transition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1101,7 +1101,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -1453,8 +1452,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20251202.0.tgz",
       "integrity": "sha512-Q7m1Ivu2fbKalOPm00KLpu6GfRaq4TlrPknqugvZgp/gDH96OYKINO4x7jvCIBvCz/aK9vVoOj8tlbSQBervVA==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -3181,7 +3179,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.4.tgz",
       "integrity": "sha512-rgXI/8/tnO3Y9tfAaUyg/8beKhlIMltbiC8Q6jCoAfEidOyaue4KYKzbe0gJIb6qEdEaG3Kf3BY3EOSLkbWOLg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -3446,7 +3443,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4779,7 +4775,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6525,7 +6520,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7038,7 +7032,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7415,7 +7408,6 @@
       "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7698,7 +7690,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -8186,7 +8177,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -8771,7 +8761,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "devOptional": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -8860,7 +8849,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/content/blog/en/ai/2026-04-09-why-im-leaving-android-for-ai.md
+++ b/src/content/blog/en/ai/2026-04-09-why-im-leaving-android-for-ai.md
@@ -1,0 +1,122 @@
+---
+title: "Why I'm Leaving Comfortable Android Development for AI"
+date: 2026-04-09
+categories: ["ai"]
+tags: ["AI", "Machine Learning", "Career Change", "Android"]
+summary: "After 10+ years of Android development, I'm diving into AI and Machine Learning. Here's why, how, and what my 6-month roadmap looks like."
+toc: true
+comments: true
+image: "/assets/images/ai/android-to-ai.jpg"
+---
+
+If you've been following [Iced Tea Labs](https://icedtealabs.com) for a while, you know me as the Android guy. Custom Views, Dagger, Hilt, Clean Architecture, RxJava — that's been my world for over a decade. I've shipped apps at Lazada, built side projects like [Buckist](https://buckist.app) and myMoney, and honestly? Android development has been *very* good to me.
+
+But something has been nagging at me for the past year.
+
+Every time I open tech news, every conference talk, every job posting that catches my eye — it all points to the same direction: **AI and Machine Learning**. And I'm not talking about the hype. I'm talking about the fundamental shift in how software is being built.
+
+So here I am, publicly committing to a new chapter: **I'm spending the next 6 months transitioning from Android engineering to Machine Learning.** And I'm going to document every step of it on this blog.
+
+## The Comfortable Trap
+
+Let's be honest. After 10+ years of Android development, I can build pretty much anything thrown at me. New Jetpack library? Give me a weekend. Compose migration? Been there. Complex RecyclerView with custom animations? Easy.
+
+And that's exactly the problem.
+
+**Comfort is the enemy of growth.** It's like staying on `compileSdkVersion 28` while the rest of the world has moved to SDK 35. Your app still compiles, it still runs — but you're slowly becoming irrelevant. You don't notice it until one day you look up and the ecosystem has moved on without you.
+
+Meanwhile, the world around us is changing fast:
+
+- The **edge AI market** is projected to grow from $25 billion to **$119 billion by 2033**
+- Google, Apple, Samsung, and Meta are actively hiring for **"Mobile ML Engineer"** roles — positions that explicitly demand both Android AND ML skills
+- On-device inference is becoming the standard, not the exception. LiteRT (formerly TensorFlow Lite), ML Kit, PyTorch Mobile — these aren't experimental anymore
+
+The intersection of mobile and ML isn't some far-off future. It's happening *right now*. And I don't want to watch from the sidelines.
+
+## Why AI? Why Now?
+
+Here's what convinced me this isn't just hype:
+
+**The job market is screaming for ML engineers.** ML engineering postings have seen a **150% year-over-year increase** as of mid-2025. But here's the surprising part: **entry-level ML roles make up only 3% of job postings**. Companies don't want fresh graduates for ML — they want it as a *second career stage*. They want people who already know how to ship production software.
+
+That's... literally us. Software engineers.
+
+Another stat that blew my mind: **23.9% of ML job listings don't even mention degree requirements**. A strong portfolio can substitute for a master's degree. You don't need to go back to university — you need to build things.
+
+And then there's the niche that made me go "wait, this role was *designed* for me": **the Mobile ML Engineer**. Google has open positions (base salary $141K–$202K+) that explicitly require *"familiarity with edge device development on Android"* combined with *"general AI and ML methods."* Apple, Samsung, Meta, Snap, and Qualcomm have similar roles.
+
+The competition for general ML Engineer positions? Brutal. The competition for Mobile ML Engineer positions that need someone who can both train a model AND deploy it on Android with smooth performance? **Much, much thinner.**
+
+## My Android Background Is Not Baggage
+
+This is the insight that really changed my perspective. When I first thought about switching to ML, my instinct was: "I need to forget everything I know and start from scratch."
+
+Wrong.
+
+My Android experience isn't baggage to shed — it's a **rare competitive weapon**. Here's how the skills translate:
+
+- **Clean Architecture / MVVM** → ML pipeline architecture. Most ML candidates write monolithic Jupyter notebooks. I'll instinctively structure code with separation of concerns, testability, and maintainability.
+- **Performance optimization** → Model optimization. Years of fighting with Android memory constraints, APK size, and render performance? That maps directly to model quantization, pruning, and latency profiling. ProGuard/R8 ≈ model compression.
+- **JUnit + Espresso testing** → ML testing. Unit testing models, integration testing APIs, CI/CD for ML pipelines — this is a *massive* gap in the ML world that software engineers can fill.
+- **Firebase A/B testing** → ML model A/B testing. Same concepts: controlled experiments, statistical significance, measuring impact on user metrics.
+
+While thousands of career changers flood into ML from non-engineering backgrounds, I already know how to write production-grade code, set up CI/CD, handle edge cases, and ship software that real users depend on. **Most ML candidates can't say that.**
+
+This isn't a career restart. It's a career **expansion**.
+
+## The 6-Month Roadmap
+
+Here's the high-level plan. I'll go deeper into each phase in future posts:
+
+**Month 1 — Python for Data Science + Statistics**
+NumPy, pandas, matplotlib, seaborn. Statistical foundations: distributions, hypothesis testing, Bayesian thinking. Capstone: a full EDA project deployed as a Streamlit app.
+
+**Month 2 — SQL + Visualization + First ML Course**
+Analytical SQL (window functions, CTEs), Tableau/Power BI dashboards. Start Andrew Ng's Machine Learning Specialization on Coursera.
+
+**Month 3 — Machine Learning with scikit-learn**
+Classical ML algorithms (random forests, XGBoost, SVMs). Feature engineering, handling messy data, the full modeling workflow. Project: customer churn prediction end-to-end.
+
+**Month 4 — Deep Learning + MLOps**
+PyTorch, CNNs, transformers, transfer learning. MLflow for experiment tracking, FastAPI + Docker for model serving. Project: NLP sentiment analysis pipeline.
+
+**Month 5 — The Capstone: ML-Powered Android App**
+This is the killer differentiator. Train a model in Python, optimize it, deploy on Android with Kotlin. On-device inference with LiteRT or PyTorch Mobile. Very few ML engineers can build polished Android apps — this is my unfair advantage.
+
+**Month 6 — Certification + Interview Prep + Job Search**
+One cloud ML certification (AWS/GCP/Azure). System design for ML. Polish the portfolio and start applying.
+
+## Building in Public
+
+I'm not just learning in private — I'm writing about every step. This is part of a **12-post blog series** covering the entire journey:
+
+1. **Why I'm leaving Android for AI** *(this post)*
+2. Math for ML: a software engineer's survival guide
+3. My first ML model: what tutorials didn't teach me
+4. SQL for data science: beyond SELECT *
+5. PyTorch from a software engineer's perspective
+6. Building my first end-to-end ML project
+7. The 80% nobody talks about: data wrangling
+8. MLOps for software engineers: CI/CD for ML
+9. Deploying ML on Android: my mobile background as a career advantage
+10. Kaggle competitions vs. real-world projects
+11. Building in public: how blogging opened unexpected doors
+12. 6 months in: the honest retrospective
+
+Why blog about it? Three reasons:
+
+- **The Feynman technique works.** If I can't explain something clearly in writing, I don't truly understand it.
+- **Accountability.** Publicly committing to a 6-month plan makes it much harder to quit when things get tough (and they will).
+- **Paying it forward.** When I started Android development, other developers' blog posts were invaluable. Time to return the favor for the next person making this transition.
+
+***
+
+I'm not going to pretend this will be easy. I'll struggle with statistics (I already know I will). I'll feel like an imposter when comparing myself to people with CS PhDs. There will be weeks where nothing makes sense and I'll want to go back to my comfortable RecyclerView adapters.
+
+But as I've learned from bouldering: **Analyze → Attempt → Fail → Adjust → Send.**
+
+The wall is set. Time to start climbing.
+
+See you in the next post — where we'll get our hands dirty with NumPy and discover why arrays are NOT lists.
+
+Happy learning! 💻🧠

--- a/src/content/blog/vi/ai/2026-04-09-why-im-leaving-android-for-ai.md
+++ b/src/content/blog/vi/ai/2026-04-09-why-im-leaving-android-for-ai.md
@@ -1,0 +1,122 @@
+---
+title: "Tại Sao Mình Rời Bỏ 'Vùng An Toàn' Android Để Lao Vào AI"
+date: 2026-04-09
+categories: ["ai"]
+tags: ["AI", "Machine Learning", "Career Change", "Android"]
+summary: "Sau hơn 10 năm gắn bó với Android, mình quyết định lao đầu vào AI và Machine Learning. Đây là lý do, cách thức, và lộ trình 6 tháng của mình."
+toc: true
+comments: true
+image: "/assets/images/ai/android-to-ai.jpg"
+---
+
+Anh em theo dõi [Iced Tea Labs](https://icedtealabs.com) chắc biết mình là dân Android "nòi". Custom Views, Dagger, Hilt, Clean Architecture, RxJava — đó là thế giới của mình suốt hơn chục năm qua. Mình đã ship app ở Lazada, build side projects như [Buckist](https://buckist.app) và myMoney, và thú thật? Cuộc sống Android dev rất ổn, rất "chill".
+
+Nhưng có một thứ cứ lởn vởn trong đầu mình suốt năm qua.
+
+Mở tin công nghệ: AI. Conference talk: AI. Job posting hay ho: AI. Không phải kiểu hype rồi xịt, mà là một sự thay đổi **tận gốc** trong cách phần mềm được xây dựng.
+
+Nên đây, mình công khai luôn: **Mình sẽ dành 6 tháng tiếp theo để chuyển từ Android Engineering sang Machine Learning.** Và mình sẽ document toàn bộ hành trình trên blog này.
+
+## Cái Bẫy Của Sự Thoải Mái
+
+Nói thật. Sau 10+ năm làm Android, mình có thể build gần như mọi thứ người ta giao. Jetpack library mới? Cho mình cuối tuần. Migrate sang Compose? Xong rồi. RecyclerView phức tạp với animation custom? Dễ ợt.
+
+Và đó chính xác là **vấn đề**.
+
+**Thoải mái chính là kẻ thù của sự phát triển.** Nó giống như anh em cứ ở yên trên `compileSdkVersion 28` trong khi cả thế giới đã lên SDK 35. App vẫn build được, vẫn chạy ngon — nhưng anh em đang dần trở nên "lỗi thời" mà không hay biết. Cho đến một ngày ngẩng đầu lên, ecosystem đã bỏ mình lại phía sau.
+
+Trong khi đó, thế giới xung quanh đang thay đổi với tốc độ chóng mặt:
+
+- Thị trường **Edge AI** được dự báo tăng từ 25 tỷ USD lên **119 tỷ USD vào năm 2033**
+- Google, Apple, Samsung, Meta đang tuyển vị trí **"Mobile ML Engineer"** — role yêu cầu cả kỹ năng Android VÀ ML
+- On-device inference đang trở thành chuẩn mực, không còn là thí nghiệm nữa. LiteRT (tên mới của TensorFlow Lite), ML Kit, PyTorch Mobile — tất cả đều production-ready
+
+Giao lộ giữa Mobile và ML không phải chuyện tương lai xa vời. Nó đang diễn ra **ngay lúc này**. Và mình không muốn chỉ ngồi xem.
+
+## Tại Sao AI? Tại Sao Là Bây Giờ?
+
+Đây là những con số thuyết phục mình rằng đây không phải hype:
+
+**Thị trường đang "khát" ML Engineer.** Số lượng job posting ML tăng **150% so với năm trước** (tính đến giữa 2025). Nhưng đây mới là phần thú vị: **chỉ có 3% job ML là entry-level**. Các công ty không muốn fresh graduate cho ML — họ muốn nó là *giai đoạn sự nghiệp thứ hai*. Họ cần người đã biết cách ship phần mềm production.
+
+Mà đó... chính là anh em mình. Software Engineer.
+
+Một con số nữa khiến mình "à há": **23.9% job ML không yêu cầu bằng cấp cụ thể**. Portfolio mạnh có thể thay thế bằng Master. Không cần quay lại trường đại học — chỉ cần build đồ thật.
+
+Và rồi mình phát hiện ra một ngách mà như được "đo ni đóng giày" cho mình: **Mobile ML Engineer**. Google đang tuyển vị trí này (lương cơ bản $141K–$202K+) với yêu cầu rõ ràng: *"quen thuộc với phát triển ứng dụng trên Android"* kết hợp *"kiến thức về AI và ML"*. Apple, Samsung, Meta, Snap, Qualcomm cũng có role tương tự.
+
+Cạnh tranh cho vị trí ML Engineer chung? Khốc liệt. Cạnh tranh cho vị trí Mobile ML Engineer cần người vừa train model vừa deploy lên Android mượt mà? **Ít hơn nhiều.**
+
+## Kinh Nghiệm Android Không Phải Hành Lý Thừa
+
+Đây là insight thay đổi hoàn toàn góc nhìn của mình. Lúc đầu nghĩ đến việc chuyển sang ML, bản năng mách bảo: "Phải quên hết mọi thứ, học lại từ đầu."
+
+Sai bét.
+
+Kinh nghiệm Android không phải hành lý thừa — nó là **vũ khí cạnh tranh hiếm có**. Skills chuyển đổi thế nào:
+
+- **Clean Architecture / MVVM** → Kiến trúc ML pipeline. Phần lớn dân ML viết code trong Jupyter notebook như một cục bột. Mình sẽ tự động structure code với separation of concerns, testability, và maintainability.
+- **Tối ưu hiệu năng** → Tối ưu model. Bao năm chiến đấu với memory Android, APK size, render performance? Map thẳng sang model quantization, pruning, và latency profiling. ProGuard/R8 ≈ model compression.
+- **JUnit + Espresso testing** → ML testing. Unit test model, integration test API, CI/CD cho ML pipeline — đây là lỗ hổng **khổng lồ** trong thế giới ML mà dân Software Engineer có thể lấp đầy.
+- **Firebase A/B testing** → ML model A/B testing. Concept y chang: controlled experiments, statistical significance, đo impact lên user metrics.
+
+Trong khi hàng nghìn người chuyển sang ML từ non-engineering background, mình đã biết viết production code, setup CI/CD, xử lý edge cases, và ship phần mềm cho user thật dùng hàng ngày. **Phần lớn ứng viên ML không có được điều đó.**
+
+Đây không phải restart sự nghiệp. Đây là **mở rộng** sự nghiệp.
+
+## Lộ Trình 6 Tháng
+
+Đây là kế hoạch tổng quan. Mình sẽ đi sâu vào từng giai đoạn trong các bài viết tiếp theo:
+
+**Tháng 1 — Python cho Data Science + Thống kê**
+NumPy, pandas, matplotlib, seaborn. Nền tảng thống kê: phân phối xác suất, kiểm định giả thuyết, tư duy Bayesian. Capstone: một dự án EDA hoàn chỉnh deploy lên Streamlit.
+
+**Tháng 2 — SQL + Visualization + Khoá ML đầu tiên**
+SQL nâng cao (window functions, CTEs), Tableau/Power BI dashboards. Bắt đầu Machine Learning Specialization của Andrew Ng trên Coursera.
+
+**Tháng 3 — Machine Learning với scikit-learn**
+Thuật toán ML cổ điển (random forests, XGBoost, SVMs). Feature engineering, xử lý data "bẩn", toàn bộ modeling workflow. Dự án: dự đoán customer churn end-to-end.
+
+**Tháng 4 — Deep Learning + MLOps**
+PyTorch, CNNs, transformers, transfer learning. MLflow cho experiment tracking, FastAPI + Docker cho model serving. Dự án: NLP sentiment analysis pipeline.
+
+**Tháng 5 — Capstone: App Android chạy ML**
+Đây là "chiêu tuyệt" của mình. Train model bằng Python, optimize, rồi deploy lên Android bằng Kotlin. On-device inference với LiteRT hoặc PyTorch Mobile. Rất ít ML Engineer có thể build app Android "ra hồn" — đây là lợi thế không cân xứng của mình.
+
+**Tháng 6 — Chứng chỉ + Luyện phỏng vấn + Tìm việc**
+Một chứng chỉ Cloud ML (AWS/GCP/Azure). System design cho ML. Polish portfolio và bắt đầu apply.
+
+## Học Công Khai
+
+Mình không chỉ học trong im lặng — mình sẽ viết về từng bước. Đây là series **12 bài blog** bao trùm toàn bộ hành trình:
+
+1. **Tại sao mình rời Android sang AI** *(bài này)*
+2. Toán cho ML: cẩm nang sinh tồn cho Software Engineer
+3. Model ML đầu tiên: những gì tutorial không dạy
+4. SQL cho Data Science: đời không chỉ có SELECT *
+5. PyTorch qua góc nhìn Software Engineer
+6. Build dự án ML end-to-end đầu tiên
+7. 80% công việc mà không ai nói đến: data wrangling
+8. MLOps cho Software Engineer: CI/CD cho ML
+9. Deploy ML lên Android: lợi thế từ background mobile
+10. Kaggle competitions vs. dự án thực tế
+11. Xây dựng trước công chúng: khi viết blog mở ra cánh cửa bất ngờ
+12. 6 tháng sau: bài retrospective trung thực
+
+Tại sao phải blog? Ba lý do:
+
+- **Feynman technique.** Nếu không giải thích được bằng văn viết, nghĩa là mình chưa thật sự hiểu.
+- **Trách nhiệm công khai.** Commit trước bàn dân thiên hạ khiến việc bỏ cuộc khó hơn rất nhiều (mà kiểu gì cũng có lúc muốn bỏ).
+- **Trả ơn cộng đồng.** Hồi mới học Android, blog của dev khác là "cứu cánh" của mình. Đến lượt mình trả lại cho người tiếp theo.
+
+***
+
+Mình không giả vờ là chuyện này sẽ dễ dàng. Mình sẽ vật lộn với thống kê (chắc chắn luôn). Sẽ có lúc cảm giác imposter khi so sánh với mấy cha PhD Computer Science. Sẽ có tuần chẳng hiểu gì hết và chỉ muốn quay về với cái RecyclerView adapter thân thương.
+
+Nhưng như mình đã học được từ bouldering: **Phân tích → Thử nghiệm → Thất bại → Điều chỉnh → Hoàn thành.**
+
+Tường đã dựng. Đến lúc bắt đầu leo rồi.
+
+Hẹn gặp anh em ở bài tiếp theo — nơi chúng ta sẽ "xắn tay" với NumPy và phát hiện ra tại sao array không phải list!
+
+Happy learning! 💻🧠


### PR DESCRIPTION
## Summary
Add the first post in a 12-part blog series documenting a career transition from Android development to Machine Learning. The post is published in both English and Vietnamese to reach a broader audience.

## Changes
- **New English post** (`src/content/blog/en/ai/2026-04-09-why-im-leaving-android-for-ai.md`): Introduces the motivation for transitioning from 10+ years of Android development to ML/AI, backed by market data and job trends. Outlines a concrete 6-month learning roadmap and explains how existing Android engineering skills translate to ML engineering.

- **New Vietnamese post** (`src/content/blog/vi/ai/2026-04-09-why-im-leaving-android-for-ai.md`): Complete Vietnamese translation of the English post, maintaining the same structure, examples, and roadmap.

## Key Content
- **Motivation**: Market analysis showing 150% YoY growth in ML job postings, edge AI market projections ($25B → $119B by 2033), and the emerging "Mobile ML Engineer" role
- **Competitive advantage**: Maps Android skills (Clean Architecture, performance optimization, testing, A/B testing) to ML engineering competencies
- **6-month roadmap**: Structured progression from Python fundamentals through deep learning, MLOps, and culminating in an ML-powered Android app as a differentiator
- **Public learning commitment**: Announces a 12-post blog series documenting the entire journey for accountability and community contribution

## Notable Details
- Positions the transition as a career expansion rather than a restart, leveraging existing production engineering expertise
- Identifies the Mobile ML Engineer niche as a less-saturated opportunity compared to general ML roles
- Emphasizes building in public as a learning and accountability mechanism

https://claude.ai/code/session_01TLjjfE5p4iVtL1SHFW8DoL