### PR TITLE
New post: Google I/O 2026 — Signal vs. Noise for Indie Hackers

### DIFF
--- a/src/content/blog/en/indie-hacker/2026-05-21-google-io-2026-signal-vs-noise-for-indie-hackers.md
+++ b/src/content/blog/en/indie-hacker/2026-05-21-google-io-2026-signal-vs-noise-for-indie-hackers.md
@@ -1,0 +1,119 @@
+---
+title: "Google I/O 2026: Signal vs. Noise for Mobile Devs and Indie Hackers"
+date: 2026-05-21T08:00:00
+categories: ["indie-hacker"]
+tags: ["Google IO", "Android", "Gemini", "AI", "Indie Hacker", "Developer Tools", "Mobile Development", "Antigravity"]
+summary: "Google I/O 2026 just wrapped. Underneath the product theater are a few announcements that will genuinely change how mobile developers and indie hackers work. Here's what actually matters — and what you can safely ignore."
+toc: true
+comments: true
+image: "https://images.unsplash.com/photo-1540575467063-178a50c2df87?w=1200&auto=format&fit=crop&q=80"
+imageAlt: "Conference stage with audience — Photo by Headway on Unsplash"
+---
+
+Every May, Google I/O delivers a flood of announcements. Most of them land on a slide, get a round of applause, and quietly disappear into the product graveyard six months later.
+
+But this year felt different.
+
+I watched the entire 2026 developer keynote and underneath the usual product theater were a few announcements that I think will genuinely shift how mobile developers and indie hackers work over the next 12 months. Not everything — a lot of it is still vaporware with great production value. But some of it is real, and I want to talk about which parts.
+
+<img src="https://images.unsplash.com/photo-1540575467063-178a50c2df87?w=1200&auto=format&fit=crop&q=80" alt="Conference audience watching a keynote stage — Google I/O 2026." />
+
+## Why This Year Was Different
+
+For the past two years, Google has been playing catch-up in the AI coding assistant race. Copilot had enterprise. Cursor had developer mindshare. Claude Code had the agentic workflow. Google had Gemini in Docs, which is polished and useful, but doesn't speak to how we actually build software.
+
+That changed at I/O 2026. Google came in with a clearly articulated developer AI strategy — not just "here's our model" but "here's how you build with it, and here's how it builds with you."
+
+Whether the execution will match the vision is a different bet. But the strategy is coherent in a way it hasn't been before.
+
+## 1. Gemini 3.5 Flash: The Agentic Model
+
+The centerpiece announcement was **Gemini 3.5 Flash** — the first in a new model series Google is explicitly positioning around *action*, not just *intelligence*.
+
+The key phrase from the keynote: "combining frontier intelligence with action."
+
+In practice: Gemini 3.5 Flash is optimized for long-horizon, multi-step tasks — planning, executing, checking, and iterating across multiple tools in a single run. The same class of capability that Claude Code or GPT-4o handle in an agentic setup.
+
+What this means for developers: Google is now directly in the agentic coding race, not as a peripheral player. Whether Gemini 3.5 Flash actually performs at Claude Opus level in real coding scenarios remains to be seen. I'll wait for the benchmarks that matter — "does it fix my bug" rather than "how does it score on MMLU."
+
+But the intent is clear. The question of which model runs your long builds and complex refactors just got more interesting.
+
+## 2. Antigravity: Google's Answer to Claude Code
+
+This one caught me off guard.
+
+Google announced **Antigravity 2.0**, an "agent-first development platform" for building and orchestrating AI agents — plus an **Antigravity CLI**, a command-line agent interface.
+
+If that description sounds familiar: it's functionally the same pitch as Claude Code.
+
+I've been using Claude Code daily for the past few months on [Buckist](https://buckist.app) and a few other side projects. It's genuinely changed how I work — my full take is [here](/en/indie-hacker/cursor-vs-claude-code-indie-hacker-honest-take). So naturally I'm curious: is Antigravity real competition, or is it Google rebranding a demo?
+
+My honest initial read:
+
+**The case for taking it seriously**: Google AI Studio is solid infrastructure, and Antigravity has deep integration with Cloud Run, Firebase, and the full Google Cloud stack. If you're building on Google's platform, that toolchain integration is a genuine advantage over Claude Code, which doesn't care what cloud you're on.
+
+**The case for skepticism**: Google has a graveyard full of developer tools that launched with great keynotes and were abandoned 18 months later. The demos were also suspiciously clean — real agentic coding sessions involve the agent going down wrong paths, needing correction, generating code that doesn't compile. I'll believe it's production-ready when I've used it for a month, not from a stage demo.
+
+I'll be testing the Antigravity CLI when it's available to developers. If it holds up, it could be a meaningful alternative for Firebase-heavy projects.
+
+## 3. Android 17 + Gemini: Your App Just Became Part of Something Bigger
+
+The announcement that I think has the most long-term implications for Android developers: **Gemini now operates directly inside Android 17**, with cross-app automation running on-device.
+
+The demo showed Gemini performing multi-step, cross-app tasks — navigating between apps, extracting data, performing actions based on natural language — without sending data off-device.
+
+For end users, this is a convenience feature. For developers building on Android, there's a more interesting implication: **your app is now a potential node in an AI-driven workflow**. If a user can instruct Gemini to "pull last week's expenses from [App X] and summarize them in [App Y]," the quality of your app's integration with Android's Gemini layer starts to matter.
+
+The developer API for this isn't fully documented yet. But it's coming, and it will create a new optimization target. The apps that integrate well with on-device Gemini will feel dramatically more capable. The apps that don't will start to feel like they were built for a different era.
+
+I've started thinking about what this means for Buckist specifically. The answer is: I don't know yet. But I'm paying attention.
+
+<img src="https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=1200&auto=format&fit=crop&q=80" alt="Multiple smartphone screens showing apps — Android 17's on-device Gemini changes what it means to be an app." />
+
+## 4. Android Studio's Kotlin Migration Tool
+
+Saving the most directly useful announcement for developers last.
+
+Google previewed an **Android Studio feature that migrates app code to native Kotlin** — any source, any origin — turning migrations that would have taken weeks into hours.
+
+If you've been building Android apps for more than a few years, you have legacy code somewhere. Maybe it's old Java modules. Maybe it's a mixed-source codebase from before Kotlin was the default. Migration has always been the kind of work you schedule for a slow quarter and never quite get to.
+
+The idea here: describe the migration target, let AI handle the mechanical parts, review the output. Exactly the kind of high-leverage AI use case that actually makes sense — applying intelligence to work that's systematic but tedious.
+
+Two honest caveats:
+
+**"Preview" is not "shipped."** This feature will need time to mature before I'd trust it on production code. Previews at I/O have a way of being 80% of the way there in demos and 60% in practice.
+
+**Migration is the easy part.** The hard part is validating behavioral equivalence after migration — does the Kotlin version actually do the same thing in all edge cases? AI writes the Kotlin. Only tests and careful review confirm correctness. Don't let the tooling make you skip that step.
+
+That said: for legacy Android migration work, this looks genuinely promising. It's on my list to test as soon as it exits preview.
+
+## 5. WebMCP: The Standard Worth Watching, Not Acting On Yet
+
+The most quietly interesting announcement was **WebMCP** — a proposed open web standard that lets developers expose structured tool interfaces so browser-based AI agents can interact with web apps.
+
+If you've been following [Model Context Protocol](/en/indie-hacker/mcp-servers-the-upgrade-your-ai-dev-setup-is-missing), this will sound familiar. MCP lets desktop AI tools connect to structured data sources. WebMCP proposes the same idea for the browser: instead of AI agents scraping your UI like a human, they interact with a defined API surface. Faster, more reliable, and far less brittle than current browser automation approaches.
+
+For indie hackers building web apps: this is worth tracking, not acting on yet. Proposed web standards take years to achieve meaningful browser support. But the direction is clear — your web app will eventually benefit from being agent-readable, not just human-readable.
+
+File this one under "get familiar with the concept now, build for it in 2027."
+
+## My Honest Takeaway
+
+Google came to I/O 2026 with more coherent developer AI strategy than I expected. Gemini 3.5 Flash, Antigravity, Android 17 integration, and WebMCP all fit into a consistent story: Google wants to be the infrastructure layer for agentic AI, from the model to the tooling to the platform to the device.
+
+That's a real strategy. Execution is a different question.
+
+Here's what I'll actually act on from this keynote:
+
+1. **Test Antigravity CLI** when it opens to developers. If it holds up for Firebase-heavy workflows, it earns a place in the stack.
+
+2. **Watch the Android 17 Gemini API documentation** closely. The first developers who understand how to make their apps feel like native Gemini participants will have a user experience advantage that compounds over time.
+
+3. **Monitor the Kotlin migration tool** as it exits preview. The potential time savings on legacy projects is real enough to revisit this every quarter.
+
+What I'll skip: anything that requires migrating my entire stack to Google Cloud to unlock the value. Tools have to fit your workflow, not replace it. If Antigravity only shines when you're all-in on Firebase, that's a different calculus for someone already running on Supabase.
+
+---
+
+*The 9to5Google live blog had solid real-time coverage if you want the full announcement list. What caught your eye from I/O this year? Especially curious whether anyone's already gotten hands on Antigravity — drop a comment.*


### PR DESCRIPTION
## Summary

- Adds a fresh blog post for icedtealabs.com inspired by trending content from dev.to, daily.dev, and increment.com
- Topic: **Google I/O 2026** — covering the developer keynote announcements through an indie hacker / mobile developer lens
- Not part of the "Android dev learn machine learning" series — completely fresh standalone post
- Uses Unsplash photos (conference stage + smartphone apps)

## Post details

**File**: `src/content/blog/en/indie-hacker/2026-05-21-google-io-2026-signal-vs-noise-for-indie-hackers.md`

**Sections covered**:
1. Gemini 3.5 Flash — Google's new agentic model
2. Antigravity 2.0 & CLI — Google's answer to Claude Code
3. Android 17 + on-device Gemini — cross-app AI automation
4. Android Studio Kotlin migration tool — weeks → hours
5. WebMCP — proposed browser AI agent standard

**Tone**: Honest, opinionated, practical — consistent with existing indie-hacker posts. References Buckist for personal grounding.

## Test plan

- [ ] Verify frontmatter parses correctly (title, date, categories, tags, image)
- [ ] Check internal links to previous posts resolve
- [ ] Confirm Unsplash images load
- [ ] Build site and check post appears in the indie-hacker category

https://claude.ai/code/session_01EomCCET9pwEia2LnPWy9UK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EomCCET9pwEia2LnPWy9UK)_